### PR TITLE
added useInterval Hook

### DIFF
--- a/lib/hooks/useInterval.js
+++ b/lib/hooks/useInterval.js
@@ -1,0 +1,41 @@
+import { useEffect, useRef, useState } from "react";
+
+export function useInterval(callback, initialDelay) {
+  const savedCallback = useRef();
+
+  const [delay, setDelay] = useState(initialDelay);
+
+  // Remember the latest callback.
+  useEffect(() => {
+    savedCallback.current = callback;
+  }, [callback]);
+
+  // Set up the interval.
+  useEffect(() => {
+    // runs the interval procedure
+    function tick() {
+      if (!savedCallback.current) return;
+      savedCallback.current();
+    }
+
+    // handling interval call
+    if (delay !== null) {
+      let id = setInterval(tick, delay);
+      return () => clearInterval(id);
+    }
+  }, [delay]);
+
+  // if delay is not set, start it with initialDelay
+  const start = (delay) => {
+    if (!delay) {
+      delay = initialDelay;
+    }
+    setDelay(delay);
+  };
+
+  const stop = () => {
+    setDelay(null);
+  };
+
+  return { start, stop };
+}

--- a/lib/hooks/useInterval.js
+++ b/lib/hooks/useInterval.js
@@ -1,6 +1,36 @@
 import { useEffect, useRef, useState } from "react";
 
+/**
+ * The useInterval hook takes in two parameters as arguments, first it takes a `callback` function
+ * and second is the `initialDelay`.
+ * It runs the callback function after every fixed interval of time.
+ * 
+ * ```js
+ * function Timer() {
+ *   const { start, stop } = useInterval(() => {
+ *     console.log('Runs every one second!')
+ *   }, 1000)
+ * 
+ *   return <div>useInterval</div>;
+ * }
+ * ```
+ * @param {() => void} callback
+ * The callback function does not take any input as argument and returns `void` on execution.
+ * @param {number} initialDelay 
+ * It sets the time period after which the callback gets called.
+ * 
+ * 
+ * @returns {{start: (delay?: number) => void, stop: () => void}}
+ */
 export function useInterval(callback, initialDelay) {
+  if (typeof callback !== 'function') {
+    throw new Error(`Invalid parameter type. 'callback' should be a function but received ${callback}`)
+  }
+
+  if (typeof initialDelay !== 'number') {
+    throw new Error(`Invalid parameter type. 'initialDelay should be a number but received ${initialDelay}'`)
+  }
+
   const savedCallback = useRef();
 
   const [delay, setDelay] = useState(initialDelay);
@@ -26,16 +56,9 @@ export function useInterval(callback, initialDelay) {
   }, [delay]);
 
   // if delay is not set, start it with initialDelay
-  const start = (delay) => {
-    if (!delay) {
-      delay = initialDelay;
-    }
-    setDelay(delay);
-  };
+  const start = (delay) => { setDelay(delay || initialDelay); };
 
-  const stop = () => {
-    setDelay(null);
-  };
+  const stop = () => { setDelay(null) };
 
   return { start, stop };
 }

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -83,6 +83,14 @@ export declare const useInputValue: <T>(
   initialState: T
 ) => [value: T, setValue: (value: any) => void];
 
+export declare const useInterval: (
+  callback: () => void,
+  delay: number
+) => {
+  start: (delay?: number) => void;
+  stop: () => void;
+};
+
 export declare const useIsomorphicLayoutEffect: (
   effect: EffectCallback,
   deps?: DependencyList

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -85,7 +85,7 @@ export declare const useInputValue: <T>(
 
 export declare const useInterval: (
   callback: () => void,
-  delay: number
+  initialDelay: number
 ) => {
   start: (delay?: number) => void;
   stop: () => void;


### PR DESCRIPTION
Added `useInterval` hook
 - Takes in a callback function as first argument, which runs after a certain delay
 - Initial delay as second argument
 - Returns two functions, `start` and `stop` for pausing and restarting the timer.