### PR TITLE
feat/19 -Adds useDeviceOSHook

### DIFF
--- a/lib/hooks/useDeviceOS.js
+++ b/lib/hooks/useDeviceOS.js
@@ -1,0 +1,33 @@
+export const useDeviceOS = () => {
+    const { platform } = navigator.userAgentData;
+    if (!!platform) return platform;
+    // For mobile emulators on browsers
+    return checkOSBasedOnAgentInfo(navigator.userAgent);
+};
+
+const checkOSBasedOnAgentInfo = info => {
+    if (info.includes('iPhone') || info.includes('iPad') ){
+        return 'iOS';
+    } else if (info.includes('Linux')) {
+        return 'Linux';
+    } else if (info.includes('Windows')) {
+        return 'Windows';
+    }
+    // For unique OS's like blackberry, tablets
+    return extractUniqueOS(info);
+};
+
+const extractUniqueOS = info => {
+    // sample info
+    // Mozilla/5.0 (iPhone; CPU iPhone OS 13_2_3 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/13.0.3 Mobile/15E148 Safari/604.1
+    const startIndex = info.indexOf('(');
+    const endIndex = info.indexOf(')');
+  
+    if (startIndex !== -1 && endIndex !== -1 && endIndex > startIndex) {
+        const deviceText = info.substring(startIndex + 1, endIndex);
+        const firstWord = deviceText.trim().split(' ')[0];
+        return firstWord.slice(0, -1);
+    } else {
+        return 'Unknown';
+    }
+};

--- a/lib/hooks/useDeviceOS.js
+++ b/lib/hooks/useDeviceOS.js
@@ -6,28 +6,25 @@ export const useDeviceOS = () => {
 };
 
 const checkOSBasedOnAgentInfo = info => {
-    if (info.includes('iPhone') || info.includes('iPad') ){
-        return 'iOS';
-    } else if (info.includes('Linux')) {
-        return 'Linux';
-    } else if (info.includes('Windows')) {
-        return 'Windows';
+    switch (true) {
+        case info.includes('iPhone') || info.includes('iPad'):
+          return 'iOS';
+        case info.includes('Linux'):
+          return 'Linux';
+        case info.includes('Windows'):
+          return 'Windows';
+        default:
+          return extractUniqueOS(info);
     }
-    // For unique OS's like blackberry, tablets
-    return extractUniqueOS(info);
 };
 
-const extractUniqueOS = info => {
-    // sample info
-    // Mozilla/5.0 (iPhone; CPU iPhone OS 13_2_3 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/13.0.3 Mobile/15E148 Safari/604.1
-    const startIndex = info.indexOf('(');
-    const endIndex = info.indexOf(')');
-  
-    if (startIndex !== -1 && endIndex !== -1 && endIndex > startIndex) {
-        const deviceText = info.substring(startIndex + 1, endIndex);
-        const firstWord = deviceText.trim().split(' ')[0];
-        return firstWord.slice(0, -1);
-    } else {
-        return 'Unknown';
+const extractUniqueOS = (info) => {
+    const regex = /\(([^)]+)\)/;
+    const matches = info.match(regex);
+    if (matches && matches.length > 1) {
+      const deviceText = matches[1];
+      const firstWord = deviceText.trim().split(' ')[0];
+      return firstWord.slice(0, -1);
     }
-};
+    return 'Unknown';
+  };

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -152,10 +152,14 @@ export declare const useUpdateEffect: (
 
 export declare const useUrgentUpdate: () => () => void;
 
+<<<<<<< HEAD
 export declare const useBatteryStatus: () => {
   level: number;
   isCharging: boolean;
 };
+=======
+export declare const useDeviceOS: () => string;
+>>>>>>> efae97c (Adds useDeviceOSHook)
 
 // utils
 

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -152,14 +152,11 @@ export declare const useUpdateEffect: (
 
 export declare const useUrgentUpdate: () => () => void;
 
-<<<<<<< HEAD
 export declare const useBatteryStatus: () => {
   level: number;
   isCharging: boolean;
 };
-=======
 export declare const useDeviceOS: () => string;
->>>>>>> efae97c (Adds useDeviceOSHook)
 
 // utils
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -28,6 +28,7 @@ export { useCookieListener } from './hooks/useCookieListener';
 export { useInterval } from './hooks/useInterval';
 export { useSize } from './hooks/useSize';
 export { useBatteryStatus } from './hooks/useBatteryStatus';
+export { useDeviceOS } from './hooks/useDeviceOS';
 
 export { If } from './utils/If';
 export { Show } from './utils/Show';


### PR DESCRIPTION
This pr adds useDeviceOS hook. 

1. It uses the browser navigator.userAgentData to find the user os.
2. If also detects the OS of the mobile emulators used in the browsers.
    > In the case of a very special/new OS, it uses string manipulation to get OS out of userAgent 