### PR TITLE
useSize hook added

### DIFF
--- a/lib/hooks/useSize.js
+++ b/lib/hooks/useSize.js
@@ -1,29 +1,31 @@
-const useSize = (ref) => {
+export const useSize = (ref) => {
   const [dimensions, setDimensions] = useState({
     width: 0,
     height: 0,
   });
 
   useEffect(() => {
+    if (!ref.current) {
+      return;
+    }
+
     const updateDimensions = () => {
-      if (ref.current) {
-        const { clientWidth, clientHeight } = ref.current;
-        setDimensions({ width: clientWidth, height: clientHeight });
-      }
+      const { clientWidth, clientHeight } = ref.current;
+      setDimensions({ width: clientWidth, height: clientHeight });
     };
 
-    // 
+    
     const resizeObserver = new ResizeObserver(updateDimensions);
 
-    if (ref.current) {
-      updateDimensions();
-      resizeObserver.observe(ref.current);
-    }
+    updateDimensions();
+    resizeObserver.observe(ref.current);
 
     return () => {
       resizeObserver.disconnect();
     };
-  }, [ref]);
+  }, [ref.current]);
 
   return dimensions;
 };
+
+

--- a/lib/hooks/useSize.js
+++ b/lib/hooks/useSize.js
@@ -1,0 +1,29 @@
+const useSize = (ref) => {
+  const [dimensions, setDimensions] = useState({
+    width: 0,
+    height: 0,
+  });
+
+  useEffect(() => {
+    const updateDimensions = () => {
+      if (ref.current) {
+        const { clientWidth, clientHeight } = ref.current;
+        setDimensions({ width: clientWidth, height: clientHeight });
+      }
+    };
+
+    // 
+    const resizeObserver = new ResizeObserver(updateDimensions);
+
+    if (ref.current) {
+      updateDimensions();
+      resizeObserver.observe(ref.current);
+    }
+
+    return () => {
+      resizeObserver.disconnect();
+    };
+  }, [ref]);
+
+  return dimensions;
+};

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -1,10 +1,10 @@
 import {
-  MutableRefObject,
-  MouseEventHandler,
-  EffectCallback,
   DependencyList,
-  ReactNode,
+  EffectCallback,
   FC,
+  MouseEventHandler,
+  MutableRefObject,
+  ReactNode
 } from "react";
 
 // hooks
@@ -131,6 +131,8 @@ export declare const useScrollPosition: () => [
 ];
 
 export declare const useSingleEffect: (effect: () => void) => void;
+
+export declare const useSize : (ref : MutableRefObject<Element | null>) => {width : number , height : number}
 
 export declare const useTitle: (title: string) => void;
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -26,6 +26,7 @@ export { useBoolToggle } from './hooks/useToggle';
 export { useCookie } from './hooks/useCookie';
 export { useCookieListener } from './hooks/useCookieListener';
 export { useInterval } from './hooks/useInterval';
+export { useSize } from './hooks/useSize';
 
 export { If } from './utils/If';
 export { Show } from './utils/Show';


### PR DESCRIPTION
# useSize() hook added

- declared initial piece of state with `{width : 0, height : 0}`
- updates the height and width using [`ResizeObserver`](https://developer.mozilla.org/en-US/docs/Web/API/ResizeObserver) inside `useEffect`

## Tasks done

- [x] The useSize() hook should return the width and height of the target element.
- [x] Ensure the hook updates the dimensions as the element size changes.
#### Additional Task
- [x] added the type declaration
