### PR TITLE
feat: add tooltip util

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -36,3 +36,4 @@ export { If } from './utils/If';
 export { Show } from './utils/Show';
 export { For } from './utils/For';
 export { RenderAfter } from './utils/RenderAfter';
+export { Tooltip } from './utils/Tooltip';

--- a/lib/utils/Tooltip.jsx
+++ b/lib/utils/Tooltip.jsx
@@ -1,0 +1,76 @@
+import { useRef, useState } from "react"
+
+export default function Tooltip({
+    children,
+    text,
+    delay,
+    className,
+    onHideClassName,
+}) {
+    const [isShown, setIsShown] = useState(false)
+    const [styles, setStyles] = useState({})
+    const triggerRef = useRef(null)
+    const tooltipRef = useRef(null)
+    const timerRef = useRef(0)
+
+    const show = () => {
+        const triggerRect = triggerRef.current.getBoundingClientRect()
+        const dimensions = { width: window.innerWidth, height: window.innerHeight }
+        const elemIsOnTopHalf = triggerRect.y < dimensions.height / 2
+        const elemIsOnLeftHalf = triggerRect.x <= dimensions.width / 2
+        setStyles(
+            {
+                ...elemIsOnLeftHalf ? { left: 0 } : { 'right': 0, direction: 'rtl' },
+                ...elemIsOnTopHalf ? { top: triggerRect.height } : { bottom: triggerRect.height * 3 }
+            }
+        )
+        setIsShown(true)
+    }
+    const hide = () => {
+        setIsShown(false)
+    }
+
+
+    const handleShowingTooltip = () => {
+        timerRef.current = setTimeout(() => show(), delay ?? 0)
+    }
+    const handleHidingTooltip = () => {
+        if (onHideClassName || tooltipRef.current == null) {
+            tooltipRef.current.className = onHideClassName
+        } else {
+            hide()
+        }
+        clearTimeout(timerRef.current)
+    }
+    const handleAnimationFinishing = (ev) => {
+        if (ev.target != tooltipRef.current) return
+        hide()
+        if (!tooltipRef.current || tooltipRef.current == null) return
+        tooltipRef.current.className = ''
+    }
+
+    return <div style={{ position: "relative", display: 'block', width: 'fit-content', height: 'fit-content' }}>
+        <div ref={triggerRef}
+            onMouseEnter={handleShowingTooltip}
+            onMouseLeave={handleHidingTooltip}
+        >
+            {children}
+        </div>
+        <div
+            style={{ ...styles, position: 'absolute' }}
+            ref={tooltipRef}
+            onAnimationEnd={handleAnimationFinishing}
+        >
+            {isShown
+                &&
+                <div
+                    style={{ position: 'fixed', zIndex: 9999 }}
+                    className={className}
+                >
+                    {text}
+
+                </div>
+            }
+        </div>
+    </div >
+}


### PR DESCRIPTION
I decided not to play with observables and use simple JS and css to determine position of tooltip. I believe this kind of behavior is enough in most cases. Tooltip ignores overflow of parent but tries to fit in viewport. 

- Tooltip is a wrapper around any element, so it is intuitive enough to associate with any block 
```javascript
<Tooltip 
  text='Tooltip text' 
  delay={400} 
  className='border rounded-md p-2' 
  onHideClassName='animate-disappear'
>
  <button>Button with tooltip</button>
</Tooltip>
```

- delay prop is added as a way to set a timer before the tooltip shows up
- I decided to not allow to add any ReactNode in tooltip cause this type of elements considered to be a TIP not a popover. But if you disagree I will make it work differently
- I wanted to keep things simple so className prop might be used to determine the position of tooltip (cause I didn't really want to add props like `left | 'right' | 'top-right` etc. If you think that such enums are necessary I'll add them
- onHideClassName prop added so user can apply animation before the tooltip is unmounted

Of course anything is can be reconsidered. That is my first contribution, so I'm ready to work closely with anyone willing to help and make things better