### PR TITLE
fix relative paths

### DIFF
--- a/lib/hooks/useConfirmExit.ts
+++ b/lib/hooks/useConfirmExit.ts
@@ -1,4 +1,4 @@
-import { off, on } from 'lib/helpers/event';
+import { off, on } from '../helpers/event';
 import { useCallback, useEffect } from 'react';
 
 export function useConfirmExit(enabled: boolean | (() => boolean), message = 'Are you sure you want to exit?') {

--- a/lib/hooks/useHold.ts
+++ b/lib/hooks/useHold.ts
@@ -1,4 +1,4 @@
-import { off, on } from 'lib/helpers/event';
+import { off, on } from '../helpers/event';
 import { type MouseEvent, useCallback, useRef, type TouchEvent } from 'react';
 type EventType = MouseEvent | TouchEvent;
 const isTouchEvent = (e: EventType): e is TouchEvent => 'touches' in e;


### PR DESCRIPTION
Hey @DavidHDev love this project, it's been my go-to for everything related to React Hooks for years now. 

<img width="992" alt="Screenshot 2024-04-09 at 6 14 45 AM" src="https://github.com/DavidHDev/react-haiku/assets/53072963/466b54e8-5041-46c5-bc9a-101c72f5c251">


I typically like working with source code over npm where I can, in grabbing the latest from `main` I ran into some relative pathing errors in the browser. Based on the conventions you've established, I believe it to be a legit bug.

I didn't see ticket for it and given I already had to resolve it on my end, I figured I'd kindly submit a fix. 🙂 

Feel free to decline, LMK if you have any questions and mostly thank you for making hooks sensible to me 