### PR TITLE
Feat/60 add use intersection observer hook

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -125,6 +125,7 @@ export default Component;
 - [`useSingleEffect()`](https://reacthaiku.dev/docs/hooks/useSingleEffect) - Run the useEffect hook strictly only once when the component is mounted!
 - [`useTitle()`](https://reacthaiku.dev/docs/hooks/useTitle) - Update the document's title from your components!
 - [`useUpdateEffect()`](https://reacthaiku.dev/docs/hooks/useUpdateEffect) - Similar to useEffect, but it skips the first render of a component, and only react to updates triggered by dependency values.
+- [`useIntersectionObserver()`](https://reacthaiku.dev/docs/hooks/useIntersectionObserver) - Provides a way to detect when an element enters or exits the viewport, with options for configuring intersection thresholds, margins, and one-time animation triggers.
 
 ### Utilities
 

--- a/lib/hooks/useIntersectionObserver.ts
+++ b/lib/hooks/useIntersectionObserver.ts
@@ -1,0 +1,43 @@
+import { useEffect, useState, useRef } from "react";
+
+type IntersectionObserverOptions = {
+  threshold?: number;
+  rootMargin?: string;
+};
+
+type UseIntersectionObserverProps = {
+  animateOnce?: boolean;
+  options?: IntersectionObserverOptions;
+};
+
+export const useIntersectionObserver = ({
+  animateOnce = false,
+  options = {}
+}: UseIntersectionObserverProps = {}) => {
+  const observeRef = useRef<Element | null>(null);
+  const [isVisible, setIsVisible] = useState(false);
+
+  useEffect(() => {
+    const currentRef = observeRef.current;
+    if (!currentRef) return;
+
+    const observer = new IntersectionObserver((entries) => {
+      const entry = entries[0];
+      if (!entry) return;
+
+      setIsVisible(entry.isIntersecting);
+
+      if (entry.isIntersecting && animateOnce) {
+        observer.disconnect();
+      }
+    }, options);
+
+    observer.observe(currentRef);
+
+    return () => {
+      observer.disconnect();
+    };
+  }, []);
+
+  return { observeRef, isVisible };
+};

--- a/lib/hooks/useIntersectionObserver.ts
+++ b/lib/hooks/useIntersectionObserver.ts
@@ -10,10 +10,15 @@ type UseIntersectionObserverProps = {
   options?: IntersectionObserverOptions;
 };
 
+type IntersectionObserverResult = {
+  observeRef: React.MutableRefObject<Element | null>;
+  isVisible: boolean;
+}
+
 export const useIntersectionObserver = ({
   animateOnce = false,
   options = {}
-}: UseIntersectionObserverProps = {}) => {
+}: UseIntersectionObserverProps = {}): IntersectionObserverResult => {
   const observeRef = useRef<Element | null>(null);
   const [isVisible, setIsVisible] = useState(false);
 

--- a/lib/hooks/useIntersectionObserver.ts
+++ b/lib/hooks/useIntersectionObserver.ts
@@ -1,7 +1,7 @@
 import { useEffect, useState, useRef } from "react";
 
 type IntersectionObserverOptions = {
-  threshold?: number;
+  threshold?: number | number[];
   rootMargin?: string;
 };
 
@@ -21,6 +21,11 @@ export const useIntersectionObserver = ({
 }: UseIntersectionObserverProps = {}): IntersectionObserverResult => {
   const observeRef = useRef<Element | null>(null);
   const [isVisible, setIsVisible] = useState(false);
+
+  if (typeof IntersectionObserver === "undefined") {
+    console.warn("IntersectionObserver is not supported in this browser.");
+    return { observeRef, isVisible: true };
+  }
 
   useEffect(() => {
     const currentRef = observeRef.current;
@@ -42,7 +47,7 @@ export const useIntersectionObserver = ({
     return () => {
       observer.disconnect();
     };
-  }, []);
+  }, [observeRef, animateOnce, options]);
 
   return { observeRef, isVisible };
 };

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -32,6 +32,7 @@ export { useFullscreen } from './hooks/useFullscreen';
 export { useDeviceOS } from './hooks/useDeviceOS';
 export { useNetwork } from './hooks/useNetwork';
 export { useTabNotification } from './hooks/useTabNotification';
+export { useIntersectionObserver } from './hooks/useIntersectionObserver';
 
 export { If } from './utils/If';
 export { Show } from './utils/Show';


### PR DESCRIPTION

# Pull Request Description

**Description**
A hook that observes changes in the intersection of a target element with viewport.

**Acceptance Criteria**
- [x] **Element Visibility:** Detects when the target element enters or exits the viewport.
- [x] **Threshold/Margin Configuration:** Allows configuration thresholds/rootMargin.
- [x] **Animate Once:** Add the option to only animate the observed element only once on scroll.
- [x] **Cleanup:** Properly disconnects the observer when the component is unmounted.

**Details:**
- The `useIntersectionObserver` hook detects when a target element enters or exits the viewport.
- It allows configuration of thresholds and root margins for intersection detection.
- Includes an option to animate the observed element only once on scroll.
- Properly disconnects the observer when the component is unmounted.
- Updated the `index.ts` file to export the `useIntersectionObserver` hook.
- Updated the `docs/README` with a description of the new hook.

**Demo:**

Here is a gif demonstrating the hook in action:

Result when passed the following options: ```const options = {observerOptions:{threshold: 1, rootMargin: "0px"}};```
![one](https://github.com/user-attachments/assets/e12bf4a8-5ff8-4fca-99aa-8d8933c43557)

Result when passed the following options: ``` const options = {animateOnce: true, observerOptions:{threshold: 1, rootMargin: "0px"}};```
![two](https://github.com/user-attachments/assets/4c95eb72-f4b0-4ea0-9be3-6fc1dc0d185d)

Result when passed the following options: ```const options = {}; ```
![three](https://github.com/user-attachments/assets/110774ad-1411-4bf9-b9ea-8273ad172418)

Result when passed the following options: ``` const options = {animateOnce: false, observerOptions:{threshold: 0, rootMargin: "200px"}};```
![four](https://github.com/user-attachments/assets/5cd7e82a-a9b1-459f-8da0-fa298d035b7a)



### Code Changes

**Hook Implementation:**
```javascript
import { useEffect, useState, useRef } from "react";

type IntersectionObserverOptions = {
  threshold?: number;
  rootMargin?: string;
};

type UseIntersectionObserverProps = {
  animateOnce?: boolean;
  options?: IntersectionObserverOptions;
};

type IntersectionObserverResult = {
  observeRef: React.MutableRefObject<Element | null>;
  isVisible: boolean;
}

export const useIntersectionObserver = ({
  animateOnce = false,
  options = {}
}: UseIntersectionObserverProps = {}): IntersectionObserverResult => {
  const observeRef = useRef<Element | null>(null);
  const [isVisible, setIsVisible] = useState(false);

  useEffect(() => {
    const currentRef = observeRef.current;
    if (!currentRef) return;

    const observer = new IntersectionObserver((entries) => {
      const entry = entries[0];
      if (!entry) return;

      setIsVisible(entry.isIntersecting);

      if (entry.isIntersecting && animateOnce) {
        observer.disconnect();
      }
    }, options);

    observer.observe(currentRef);

    return () => {
      observer.disconnect();
    };
  }, []);

  return { observeRef, isVisible };
};
```

**Index File Update:**
```typescript
export { useIntersectionObserver } from './hooks/useIntersectionObserver';
// ...other exports
```

**Documentation Update:**
Added a description of the `useIntersectionObserver` hook to the `docs/README` file.
```
- [`useIntersectionObserver()`](https://reacthaiku.dev/docs/hooks/useIntersectionObserver) - Provides a way to detect when an element enters or exits the viewport, with options for configuring intersection thresholds, margins, and one-time animation triggers.