### PR TITLE
Update: Adding missing documentation features for useWindowSize hook

### DIFF
--- a/docs/demo/UseWindowSizeDemo.jsx
+++ b/docs/demo/UseWindowSizeDemo.jsx
@@ -1,0 +1,14 @@
+import { useWindowSize} from "react-haiku"
+import React from 'react';
+import './demo.css';
+
+export const UseWindowSizeDemo = () => {
+  const {height, width} = useWindowSize();
+    return (
+        <div className="demo-container-center">
+          <b style={{ "marginBottom": "1em" }}>Resize Your Window!</b>
+           <p style={{ "marginBottom": "0" }}>Window Height: <span style={{"color": "#E46B39"}}>{height}</span></p>
+           <p style={{ "marginBottom": "0" }}>Window Width: <span style={{"color": "#E46B39"}}>{width}</span></p>
+        </div>
+    );
+}

--- a/docs/docs/hooks/useWindowSize.mdx
+++ b/docs/docs/hooks/useWindowSize.mdx
@@ -1,0 +1,44 @@
+# useWindowSize()
+
+The `useWindowSize()` hook forces a component to re-render when it gets called from anywhere inside it.
+
+### Import
+
+```jsx
+import { useWindowSize } from 'react-haiku';
+```
+
+### Usage
+
+import { UseWindowSizeDemo } from '../../demo/UseWindowSizeDemo.jsx';
+
+<UseWindowSizeDemo />
+
+```jsx
+import { useState, useEffect } from "react";
+
+type WindowSizeProps = {
+  width: number;
+  height: number;
+};
+
+export const useWindowSize = (): WindowSizeProps => {
+  const [windowSize, setWindowSize] = useState<WindowSizeProps>({
+    width: window.innerWidth, 
+    height: window.innerHeight
+  });
+
+  useEffect(() =>{
+    const handleResize = () => {
+    setWindowSize({ 
+      width: window.innerWidth, 
+      height: window.innerHeight
+    })
+  }
+
+  window.addEventListener("resize", handleResize);
+  return () => window.removeEventListener("resize", handleResize);
+  }, [])
+  return windowSize;
+} 
+```


### PR DESCRIPTION
# Pull Request Description

**Description**
Added ```UseWindowSizeDemo.jsx``` and ```useWindowSize.mdx``` files for documentation details.

Acceptance Criteria

 - [x] The documentation for a hook/utility should show, as best as possible, how it works in action, so a complete usage example
 - [x] The newly added item should be referenced in all other instances where other items are referenced in the docs/readme.

**Note**
```useWindowSize``` is referenced in docs/readme but not in root/readme. 


**Demo:**
![useWindowSizeDocs](https://github.com/user-attachments/assets/be2dc1bb-2a13-4798-b9a6-54a2df73fd41)



