### PR TITLE
Fix: The codeblock in the 'Usage" section was wrong.

### DIFF
--- a/docs/docs/hooks/useWindowSize.mdx
+++ b/docs/docs/hooks/useWindowSize.mdx
@@ -15,30 +15,15 @@ import { UseWindowSizeDemo } from '../../demo/UseWindowSizeDemo.jsx';
 <UseWindowSizeDemo />
 
 ```jsx
-import { useState, useEffect } from "react";
+import { useWindowSize} from "react-haiku"
 
-type WindowSizeProps = {
-  width: number;
-  height: number;
-};
-
-export const useWindowSize = (): WindowSizeProps => {
-  const [windowSize, setWindowSize] = useState<WindowSizeProps>({
-    width: window.innerWidth, 
-    height: window.innerHeight
-  });
-
-  useEffect(() =>{
-    const handleResize = () => {
-    setWindowSize({ 
-      width: window.innerWidth, 
-      height: window.innerHeight
-    })
-  }
-
-  window.addEventListener("resize", handleResize);
-  return () => window.removeEventListener("resize", handleResize);
-  }, [])
-  return windowSize;
-} 
+export const Component = () => {
+  const {height, width} = useWindowSize();
+    return (
+        <div>
+           <p>Window Height: {height}</p>
+           <p>Window Width: {width}</p>
+        </div>
+    );
+}
 ```


### PR DESCRIPTION
I was going over the documentation and realized I had the wrong code in the "Usage" section of the `useWindowSize.mdx`. I had posted the actual implementation code and not example code for using the hook.