### PR TITLE
Feat/58 add use size documentation

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -127,6 +127,7 @@ export default Component;
 - [`useUpdateEffect()`](https://reacthaiku.dev/docs/hooks/useUpdateEffect) - Similar to useEffect, but it skips the first render of a component, and only react to updates triggered by dependency values.
 - [`useOrientation()`](https://reacthaiku.dev/docs/hooks/useOrientation) - Detect when device is in portrait or landscape mode.
 - [`useWindowSize()`](https://reacthaiku.dev/docs/hooks/useWindowSize) - Use hook to get width and height of window. Values update upon window resizing.
+- [`useSize()`](https://reacthaiku.dev/docs/hooks/useSize) - hook observes a referenced DOM element and returns its current width and height, updating the values whenever the element is resized. This is useful for dynamically tracking size changes of any resizable component.
 
 ### Utilities
 

--- a/docs/demo/UseSizeDemo.jsx
+++ b/docs/demo/UseSizeDemo.jsx
@@ -1,0 +1,29 @@
+import { useSize} from "react-haiku"
+import React from 'react';
+import './demo.css';
+
+export const UseSizeDemo = () => {
+  const elementRef = React.useRef(null);
+  const { width, height } = useSize(elementRef);
+    return (
+        <div className="demo-container-center">
+          <b style={{ "marginBottom": "1em", "marginTop": "1.5em" }}>Resize Me!</b>
+          <div
+            ref={elementRef}
+            style={{
+              "resize": "both",
+              "overflow": "auto",
+              "padding": "1em",
+              "border": "1px solid #ccc",
+              "width": "200px",
+              "height": "200px",
+              "marginBottom": "2em",
+              "border": "solid #E46B39",
+            }}
+          >
+            <p style={{ "marginBottom": "0" }}>Width: <span style={{"color": "#E46B39"}}>{width}</span>px</p>
+            <p style={{ "marginBottom": "0" }}>Height: <span style={{"color": "#E46B39"}}>{height}</span>px</p>
+          </div>
+        </div>
+    );
+}

--- a/docs/docs/hooks/useSize.mdx
+++ b/docs/docs/hooks/useSize.mdx
@@ -1,0 +1,39 @@
+# useSize()
+
+The `useSize` hook observes a referenced DOM element and returns its current width and height, updating the values whenever the element is resized. This is useful for dynamically tracking size changes of any resizable component.
+
+### Import
+
+```jsx
+import { useSize } from 'react-haiku';
+```
+
+### Usage
+
+import { UseSizeDemo } from '../../demo/UseSizeDemo.jsx';
+
+<UseSizeDemo />
+
+```jsx
+
+import { useRef } from "react"
+import { useSize } from "react-haiku"
+
+export const Component = () => {
+  const elementRef = useRef(null);
+  const { width, height } = useSize(elementRef);
+
+  return (
+      <div ref={elementRef}>
+          <p>Window Height: {height}</p>
+          <p>Window Width: {width}</p>
+      </div>
+  );
+}
+
+```
+
+### API
+This hook accepts the following arguments:
+
+- `ref` - a reference to the DOM element you want to observe for size changes.

--- a/docs/docs/hooks/useWindowSize.mdx
+++ b/docs/docs/hooks/useWindowSize.mdx
@@ -15,30 +15,15 @@ import { UseWindowSizeDemo } from '../../demo/UseWindowSizeDemo.jsx';
 <UseWindowSizeDemo />
 
 ```jsx
-import { useState, useEffect } from "react";
+import { useWindowSize} from "react-haiku"
 
-type WindowSizeProps = {
-  width: number;
-  height: number;
-};
-
-export const useWindowSize = (): WindowSizeProps => {
-  const [windowSize, setWindowSize] = useState<WindowSizeProps>({
-    width: window.innerWidth, 
-    height: window.innerHeight
-  });
-
-  useEffect(() =>{
-    const handleResize = () => {
-    setWindowSize({ 
-      width: window.innerWidth, 
-      height: window.innerHeight
-    })
-  }
-
-  window.addEventListener("resize", handleResize);
-  return () => window.removeEventListener("resize", handleResize);
-  }, [])
-  return windowSize;
-} 
+export const Component = () => {
+  const {height, width} = useWindowSize();
+    return (
+        <div>
+           <p>Window Height: {height}</p>
+           <p>Window Width: {width}</p>
+        </div>
+    );
+}
 ```


### PR DESCRIPTION
# Pull Request Description

**Description**
Added ```UseSizeDemo.jsx``` and ```useSize.mdx``` files for documentation details. Also, added `useSize` to `docs/README.md`.

Acceptance Criteria

 - [x] The documentation for a hook/utility should show, as best as possible, how it works in action, so a complete usage example
 - [x] The newly added item should be referenced in all other instances where other items are referenced in the docs/readme.

**Demo:**
![useSize](https://github.com/user-attachments/assets/9ef8e785-3cb0-4976-8410-b7a76e10643e)
