### PR TITLE
Feature: added documentation and demo for useFullscreen hook

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -117,6 +117,7 @@ export default Component;
 - [`useEventListener()`](https://reacthaiku.dev/docs/hooks/useEventListener) - Set event listeners on the window object or a specific target element!
 - [`useFavicon()`](https://reacthaiku.dev/docs/hooks/useFavicon) - Dynamically update the website's favicon from a component!
 - [`useFirstRender()`](https://reacthaiku.dev/docs/hooks/useFirstRender) - Check whether or not a component is on its first render!
+- [`useFullscreen()`](https://reacthaiku.dev/docs/hooks/useFullscreen) - Toggle between entering fullscreen mode and exiting fullscreen mode!
 - [`useHold()`](https://reacthaiku.dev/docs/hooks/useHold) - Handle long presses on a target element and execute a handler after a set delay!
 - [`useIdle()`](https://reacthaiku.dev/docs/hooks/useIdle) - Detect user activity/inactivity on the page based on events!
 - [`useIsomorphicLayoutEffect()`](https://reacthaiku.dev/docs/hooks/useIsomorphicLayoutEffect) - Switch between useEffect and useLayoutEffect depending on the execution environment (SSR VS Browser)!

--- a/docs/demo/UseFullscreenDemo.jsx
+++ b/docs/demo/UseFullscreenDemo.jsx
@@ -1,0 +1,19 @@
+import { useFullscreen } from 'react-haiku'
+import React from 'react'
+import './demo.css';
+
+export const UseFullscreenDemo = () => {
+  const documentRef = React.useRef(null);
+
+  React.useEffect(() => {
+    documentRef.current = document.documentElement;
+  }, []);
+
+  const {isFullscreen, toggleFullscreen } = useFullscreen(documentRef);
+  return (
+      <div className="demo-container-center">
+        <b style={{"marginBottom": "1em"}}>Is in Fullscreen Mode: <span style={{"color": "#E46B39"}}>{isFullscreen ? "True" : "False"}</span></b>
+        <button className='demo-button' onClick={toggleFullscreen}>Toggle Fullscreen!</button>
+      </div>
+  );
+}

--- a/docs/docs/hooks/useFullscreen.mdx
+++ b/docs/docs/hooks/useFullscreen.mdx
@@ -1,0 +1,65 @@
+# useFullscreen()
+
+The `useFullscreen()` hook can toggle between entering fullscreen mode and exiting fullscreen mode.
+
+### Import
+
+```jsx
+import { useFullscreen } from 'react-haiku';
+```
+
+### Usage
+
+import { UseFullscreenDemo } from '../../demo/UseFullscreenDemo.jsx';
+
+<UseFullscreenDemo />
+
+#### For Overall Document
+
+```jsx
+
+import { useEffect, useRef } from 'react'
+import { useFullscreen } from 'react-haiku';
+
+export const Component = () => {
+  const documentRef = useRef(null);
+
+  useEffect(() => {
+    documentRef.current = document.documentElement;
+  }, []);
+
+  const {isFullscreen, toggleFullscreen } = useFullscreen(documentRef);
+  return (
+      <div>
+        <b>Is in Fullscreen Mode: {isFullscreen ? "True" : "False"}</b>
+        <button onClick={toggleFullscreen}>Toggle Fullscreen!</button>
+      </div>
+  );
+}
+
+```
+
+#### For Specific Element
+
+```jsx
+
+import { useEffect } from 'react'
+import { useFullscreen } from 'react-haiku';
+
+export const Component = () => {
+  const elementRef = useRef(null);
+  const {isFullscreen, toggleFullscreen } = useFullscreen(elementRef);
+  return (
+      <div ref={elementRef}>
+        <b>Is in Fullscreen Mode: {isFullscreen ? "True" : "False"}</b>
+        <button onClick={toggleFullscreen}>Toggle Fullscreen!</button>
+      </div>
+  );
+}
+
+```
+
+### API
+
+This hook accepts the following arguments:
+- `targetRef` - a reference to the DOM element you want to toggle fullscreen for.


### PR DESCRIPTION
# Pull Request Description

**Description**
Added ```UseFullscreenDemo.jsx``` and ```useFullscreen.mdx``` files for documentation details. Also, added `useFullscreen` to `docs/README.md`.

Acceptance Criteria

 - [x] The documentation for a hook/utility should show, as best as possible, how it works in action, so a complete usage example
 - [x] The newly added item should be referenced in all other instances where other items are referenced in the docs/readme.
 
**Note**
   I added two examples to the `useFullscreen.mdx` file because I wasn't sure if this hook was _only_ supposed to be used for making a window fullscreen. The first example shows with the document.documentElement being used; however, if this was the intended purpose, couldn't it just be done in the hook itself?
  It will also work with an element, but then _only_ that element is enlarged to fullscreen, not the entire document. I looked through previous pull requests but the one I saw mentioning it didn't explicitly define which purpose was intended, unless I overlooked it. If the option is intentional, I would imagine a refactor could be made where the hook would set the document.documentElement by default _unless_ another reference was passed to it. Either way, here is how it looks at the moment.

**Demo:**
![useFullscreen](https://github.com/user-attachments/assets/d89612c3-34d0-4dbb-b60b-57602959b2a0)
