### PR TITLE
59: [FEAT] Create Hook - usePreventBodyScroll()

### DIFF
--- a/lib/hooks/usePreventBodyScroll.ts
+++ b/lib/hooks/usePreventBodyScroll.ts
@@ -1,0 +1,36 @@
+import { useEffect, useState } from 'react';
+
+enum ScrollState {
+  SCROLL = '',
+  LOCK = 'hidden',
+}
+
+type PreventBodyScrollResult = {
+  isScrollLocked: boolean;
+  setIsScrollLocked: React.Dispatch<React.SetStateAction<boolean>>;
+  toggleScrollLock: () => void;
+};
+
+export function usePreventBodyScroll(): PreventBodyScrollResult {
+  const [isScrollLocked, setIsScrollLocked] = useState<boolean>(false);
+
+  useEffect(() => {
+    if (isScrollLocked) {
+      document.body.style.overflow = ScrollState.LOCK;
+    } else {
+      document.body.style.overflow = ScrollState.SCROLL;
+    }
+
+    return () => {
+      document.body.style.overflow = ScrollState.SCROLL;
+    };
+  }, [isScrollLocked]);
+
+  const toggleScrollLock = () => setIsScrollLocked((prevState) => !prevState);
+
+  return {
+    isScrollLocked,
+    setIsScrollLocked,
+    toggleScrollLock,
+  };
+}

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -35,6 +35,7 @@ export { useTabNotification } from './hooks/useTabNotification';
 export { useOrientation } from './hooks/useOrientation';
 export { useWindowSize } from './hooks/useWindowSize';
 export { useIntersectionObserver } from './hooks/useIntersectionObserver';
+export { usePreventBodyScroll } from './hooks/usePreventBodyScroll';
 
 export { If } from './utils/If';
 export { Show } from './utils/Show';


### PR DESCRIPTION
**Description**
A hook that prevents body scrolling, is useful for modals or overlays.

**Acceptance Criteria**
- [x] Prevent Scrolling: When active, body scrolling is disabled.
- [x] Restore Scrolling: Scrolling is restored when the hook is inactive or the component is unmounted.
- [x] Toggle Support: Provides a way to toggle scroll prevention dynamically.

**Details**
- The `usePreventBodyScroll` hook disables the scroll when active and enables when not active.
- The hook prevents body scrolling by setting `document.body.style.overflow` to `hidden` when active, ensuring the background remains static, which is particularly useful for modals or overlays.
- When the hook is deactivated or the component is unmounted, scrolling is automatically restored by resetting the empty style to an empty state.
- The hook provides a `toggleScrollLock` function that allows dynamic control of the scroll lock, enabling easy switching between locked and unlocked states.
- It returns a `boolean` state `isScrollLocked` that indicates whether scrolling is currently disabled, along with a `setIsScrollLocked` function to manually control this state.
- The hook ensures that any changes to the `overflow` style are cleaned up when the component unmounts, preventing potential side effects in other parts of the application.