### PR TITLE
[FEAT]: `usePointerFine()` Hook

### DIFF
--- a/docs/demo/UsePointerFineDemo.jsx
+++ b/docs/demo/UsePointerFineDemo.jsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import { usePointerFine } from 'react-haiku';
+
+export const UsePointerFineDemo = () => {
+  const hasFinePointer = usePointerFine();
+
+  return (
+    <div className="demo-container-center">
+      {hasFinePointer
+        ? "🖱️ You're using a mouse or other fine pointer!"
+        : '📱 Touch or coarse pointer detected'}
+    </div>
+  );
+};

--- a/docs/docs/hooks/usePointerFine.mdx
+++ b/docs/docs/hooks/usePointerFine.mdx
@@ -1,0 +1,43 @@
+# usePointerFine()
+
+The `usePointerFine()` hook detects whether the user's primary input mechanism is a fine-grained pointer device (like a mouse, stylus, or touchpad). This is useful for adapting UI behavior based on input capabilities.
+
+> Uses the CSS media query [`(pointer: fine)`](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/pointer#fine) to detect precise pointing devices. Automatically updates when device orientation changes.
+
+### Import
+
+```jsx
+import { usePointerFine } from 'react-haiku';
+```
+
+### Usage
+
+import { UsePointerFineDemo } from '../../demo/UsePointerFineDemo.jsx';
+
+<UsePointerFineDemo />
+
+```jsx
+import { usePointerFine } from 'react-haiku';
+
+export const Component = () => {
+  const hasFinePointer = usePointerFine();
+
+  return (
+    <div>
+      {hasFinePointer
+        ? "🖱️ You're using a mouse or other fine pointer!"
+        : '📱 Touch or coarse pointer detected'}
+    </div>
+  );
+};
+```
+
+### API
+
+#### Arguments
+
+- This hook requires no arguments
+
+#### Returns
+
+- `isPointerFine` - Boolean indicating whether the primary input device supports fine-grained pointing (true = fine pointer like mouse/stylus, false = coarse pointer like touch)

--- a/lib/hooks/usePointerFine.ts
+++ b/lib/hooks/usePointerFine.ts
@@ -1,0 +1,61 @@
+import { useEffect, useState } from 'react';
+
+/**
+ * Hook that detects whether the user's primary input mechanism is a fine-grained pointer device.
+ *
+ * Fine pointers are devices like mice, styluses, or touchpads that can accurately
+ * hover and make precise selections. This is useful for adapting UI behavior based
+ * on input capabilities.
+ *
+ * @returns {boolean} `true` if the device has a fine pointer (e.g., mouse), `false` otherwise
+ *
+ * @example
+ * ```tsx
+ * const HasFinePointer = () => {
+ *   const isFinePointer = usePointerFine();
+ *
+ *   return (
+ *     <div>
+ *       {isFinePointer ? 'Using a mouse!' : 'Touch or coarse pointer detected'}
+ *     </div>
+ *   );
+ * };
+ * ```
+ *
+ * @see https://developer.mozilla.org/en-US/docs/Web/CSS/@media/pointer#fine
+ */
+export function usePointerFine(): boolean {
+  const checkPointerCapability = (): boolean => {
+    if (typeof window === 'undefined') return false;
+    return window.matchMedia('(pointer: fine)').matches;
+  };
+
+  const [hasFinePointer, setHasFinePointer] = useState(checkPointerCapability);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+
+    const mediaQuery = window.matchMedia('(pointer: fine)');
+
+    const handlePointerChange = (): void => {
+      setHasFinePointer(mediaQuery.matches);
+    };
+
+    mediaQuery.addEventListener('change', handlePointerChange);
+
+    // Re-check on resize and orientation changes
+    // (some devices switch pointer types on rotation)
+    window.addEventListener('resize', handlePointerChange);
+    window.addEventListener('orientationchange', handlePointerChange);
+
+    handlePointerChange();
+
+    return () => {
+      mediaQuery.removeEventListener('change', handlePointerChange);
+      window.removeEventListener('resize', handlePointerChange);
+      window.removeEventListener('orientationchange', handlePointerChange);
+    };
+  }, []);
+
+  return hasFinePointer;
+}

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -44,6 +44,7 @@ export { usePermission, UsePermissionState } from './hooks/usePermission';
 export { useTimer } from './hooks/useTimer';
 export { useWebSocket } from './hooks/useWebSocket';
 export { useGeolocation } from './hooks/useGeolocation';
+export { usePointerFine } from './hooks/usePointerFine';
 
 export { If } from './utils/If';
 export { Show } from './utils/Show';

--- a/lib/tests/hooks/usePointerFine.test.tsx
+++ b/lib/tests/hooks/usePointerFine.test.tsx
@@ -1,0 +1,196 @@
+import { renderHook, act } from '@testing-library/react';
+import { usePointerFine } from '../../hooks/usePointerFine';
+
+describe('usePointerFine', () => {
+  let mockMatchMedia: jest.Mock;
+  let mediaQueryListMock: {
+    matches: boolean;
+    media: string;
+    addEventListener: jest.Mock;
+    removeEventListener: jest.Mock;
+    onchange: null;
+    addListener: jest.Mock;
+    removeListener: jest.Mock;
+    dispatchEvent: jest.Mock;
+  };
+
+  beforeEach(() => {
+    mediaQueryListMock = {
+      matches: false,
+      media: '(pointer: fine)',
+      addEventListener: jest.fn(),
+      removeEventListener: jest.fn(),
+      onchange: null,
+      addListener: jest.fn(),
+      removeListener: jest.fn(),
+      dispatchEvent: jest.fn(),
+    };
+
+    mockMatchMedia = jest.fn().mockImplementation((query: string) => {
+      mediaQueryListMock.media = query;
+      return mediaQueryListMock;
+    });
+
+    Object.defineProperty(window, 'matchMedia', {
+      writable: true,
+      enumerable: true,
+      configurable: true,
+      value: mockMatchMedia,
+    });
+
+    // Mock resize and orientationchange events
+    window.addEventListener = jest.fn();
+    window.removeEventListener = jest.fn();
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should return true when fine pointer is detected', () => {
+    mediaQueryListMock.matches = true;
+
+    const { result } = renderHook(() => usePointerFine());
+
+    expect(mockMatchMedia).toHaveBeenCalledWith('(pointer: fine)');
+    expect(result.current).toBe(true);
+  });
+
+  it('should return false when fine pointer is not detected', () => {
+    mediaQueryListMock.matches = false;
+
+    const { result } = renderHook(() => usePointerFine());
+
+    expect(result.current).toBe(false);
+  });
+
+  it('should return false when window is undefined', () => {
+    const originalWindow = globalThis.window;
+    // @ts-expect-error - intentionally undefined for testing
+    globalThis.window = undefined;
+
+    const { result } = renderHook(() => usePointerFine());
+
+    expect(result.current).toBe(false);
+
+    globalThis.window = originalWindow;
+  });
+
+  it('should add event listeners for change, resize, and orientationchange', () => {
+    renderHook(() => usePointerFine());
+
+    expect(mediaQueryListMock.addEventListener).toHaveBeenCalledWith(
+      'change',
+      expect.any(Function),
+    );
+    expect(window.addEventListener).toHaveBeenCalledWith(
+      'resize',
+      expect.any(Function),
+    );
+    expect(window.addEventListener).toHaveBeenCalledWith(
+      'orientationchange',
+      expect.any(Function),
+    );
+  });
+
+  it('should update when change event fires', () => {
+    const { result } = renderHook(() => usePointerFine());
+
+    // Initially false
+    expect(result.current).toBe(false);
+
+    // Simulate media query change to true
+    mediaQueryListMock.matches = true;
+    const changeHandler = mediaQueryListMock.addEventListener.mock.calls.find(
+      ([event]) => event === 'change',
+    )?.[1];
+
+    act(() => {
+      changeHandler?.();
+    });
+
+    expect(result.current).toBe(true);
+  });
+
+  it('should update when resize event fires', () => {
+    const { result } = renderHook(() => usePointerFine());
+
+    // Initially false
+    expect(result.current).toBe(false);
+
+    // Simulate media query change to true on resize
+    mediaQueryListMock.matches = true;
+    const resizeHandler = (
+      window.addEventListener as jest.Mock
+    ).mock.calls.find(([event]) => event === 'resize')?.[1];
+
+    act(() => {
+      resizeHandler?.();
+    });
+
+    expect(result.current).toBe(true);
+  });
+
+  it('should update when orientationchange event fires', () => {
+    const { result } = renderHook(() => usePointerFine());
+
+    // Initially false
+    expect(result.current).toBe(false);
+
+    // Simulate media query change to true on orientation change
+    mediaQueryListMock.matches = true;
+    const orientationHandler = (
+      window.addEventListener as jest.Mock
+    ).mock.calls.find(([event]) => event === 'orientationchange')?.[1];
+
+    act(() => {
+      orientationHandler?.();
+    });
+
+    expect(result.current).toBe(true);
+  });
+
+  it('should cleanup event listeners on unmount', () => {
+    const { unmount } = renderHook(() => usePointerFine());
+
+    unmount();
+
+    const changeHandler = mediaQueryListMock.addEventListener.mock.calls.find(
+      ([event]) => event === 'change',
+    )?.[1];
+    const resizeHandler = (
+      window.addEventListener as jest.Mock
+    ).mock.calls.find(([event]) => event === 'resize')?.[1];
+    const orientationHandler = (
+      window.addEventListener as jest.Mock
+    ).mock.calls.find(([event]) => event === 'orientationchange')?.[1];
+
+    expect(mediaQueryListMock.removeEventListener).toHaveBeenCalledWith(
+      'change',
+      changeHandler,
+    );
+    expect(window.removeEventListener).toHaveBeenCalledWith(
+      'resize',
+      resizeHandler,
+    );
+    expect(window.removeEventListener).toHaveBeenCalledWith(
+      'orientationchange',
+      orientationHandler,
+    );
+  });
+
+  it('should call handlePointerChange on initial render', () => {
+    mediaQueryListMock.matches = true;
+
+    const { result } = renderHook(() => usePointerFine());
+
+    // Verify the initial state handler was called
+    mediaQueryListMock.addEventListener.mock.calls.find(
+      ([event]) => event === 'change',
+    )?.[1];
+
+    // We can't easily test the initial call to handlePointerChange
+    // but we can verify the hook returns the correct initial value
+    expect(result.current).toBe(true);
+  });
+});


### PR DESCRIPTION
# Add usePointerFine Hook

Adds the `usePointerFine()` hook that detects whether the user's primary input mechanism is a fine-grained pointer device (mouse, stylus, or touchpad).

## Features

- Detects fine pointer devices using CSS media query `(pointer: fine)`
- Updates on device orientation and resize changes
- SSR-safe (handles undefined window)
- Automatically cleans up event listeners

## Use Cases

- Adapt hover interactions based on device capabilities
- Show/hide precision controls based on input method
- Adjust UI layouts for touch vs mouse input

## Implementation

Uses the native `matchMedia` API to detect pointer capabilities and listens for `change`, `resize`, and `orientationchange` events.

## Screenshots
**Fine Pointer**
<img width="1656" height="999" alt="image" src="https://github.com/user-attachments/assets/82e48861-797f-4707-bd86-8a0c143bc789" />

**Coarse Pointer (else)**
<img width="1656" height="999" alt="image" src="https://github.com/user-attachments/assets/cdaa2128-9966-4cc0-b2fb-758701c70a41" />

Resolves #100 